### PR TITLE
Licence added: CC-BY-SA 3.0

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,29 @@
+.. (C) 2013, Scott Torberg
+
+**All \*.rst files in this project are licensed under the**
+`Creative Commons Attribution - Share Alike 3.0`_.
+
+Attribution: Scott Torberg
+
+**You are free**:
+
+ - **To share** – *to copy, distribute and transmit the work*.
+ - **To remix** – *to adapt the work*.
+ - **Commercial use** - *You may use this work for commercial purposes*.
+
+**Under the following conditions**:
+
+ - **Attribution** – *You must attribute the work in the manner specified by
+   the author or licensor, but not in any way that
+   suggests that they endorse you or your use
+   of the work.*
+
+ - **Share Alike** – *If you alter, transform, or build upon this work, you
+   may distribute the resulting work only under the same
+   or similar license to this one.*
+
+
+
+
+
+.. _Creative Commons Attribution - Share Alike 3.0: http://creativecommons.org/licenses/by-sa/3.0/

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 This tutorial is hosted at http://www.scotttorborg.com/python-packaging/
 
 Feedback is welcome, please submit a pull request or email storborg@gmail.com.

--- a/about.rst
+++ b/about.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 About This Tutorial / Contributing
 ==================================
 

--- a/command-line-scripts.rst
+++ b/command-line-scripts.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Command Line Scripts
 ====================
 

--- a/dependencies.rst
+++ b/dependencies.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Specifying Dependencies
 =======================
 

--- a/everything.rst
+++ b/everything.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Putting It All Together
 =======================
 

--- a/funniest/funniest/__init__.py
+++ b/funniest/funniest/__init__.py
@@ -1,3 +1,6 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+
 from markdown import markdown
 
 def joke():

--- a/funniest/funniest/command_line.py
+++ b/funniest/funniest/command_line.py
@@ -1,3 +1,6 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+
 from . import joke
 
 

--- a/funniest/funniest/tests/__init__.py
+++ b/funniest/funniest/tests/__init__.py
@@ -1,0 +1,3 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+

--- a/funniest/funniest/tests/test_command_line.py
+++ b/funniest/funniest/tests/test_command_line.py
@@ -1,3 +1,6 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+
 from unittest import TestCase
 
 from funniest.cmd import main

--- a/funniest/funniest/tests/test_joke.py
+++ b/funniest/funniest/tests/test_joke.py
@@ -1,3 +1,6 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+
 from unittest import TestCase
 
 import funniest

--- a/funniest/setup.py
+++ b/funniest/setup.py
@@ -1,3 +1,6 @@
+## This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+## (C) 2013, Scott Torberg
+
 from setuptools import setup
 
 def readme():

--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 How To Package Your Python Code
 ===============================
 

--- a/metadata.rst
+++ b/metadata.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Better Package Metadata
 =======================
 

--- a/minimal.rst
+++ b/minimal.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Minimal Structure
 =================
 

--- a/non-code-files.rst
+++ b/non-code-files.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Adding Non-Code Files
 =====================
 

--- a/testing.rst
+++ b/testing.rst
@@ -1,3 +1,6 @@
+.. This document is licensed under `CC-BY-SA <http://creativecommons.org/licenses/by-sa/3.0/>`
+.. (C) 2013, Scott Torberg
+
 Let There Be Tests
 ==================
 


### PR DESCRIPTION
To enable other people the usage of this text a public license was added.
Although it's generally better to use a software license like GPL for the
source code, it was decided to license the source code here under the same
license, because it's basically a demonstration code base and not really meant
for any productive use.

As the author of this commit and all appending changes I, Erik Bernoth, hereby
grant full CC-BY-SA 3.0 rights to all contributions added by this commit.

Signed-off-by: Erik Bernoth erik.bernoth@gmail.com
