### PR TITLE
Following PEP8 guidelines on import

### DIFF
--- a/minimal.rst
+++ b/minimal.rst
@@ -133,7 +133,7 @@ For example, let's move our one function to a new ``text`` submodule, so our dir
 
 In ``__init__.py``::
 
-    from .text import joke
+    from funniest import text
 
 In ``text.py``::
 


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#imports
1) Use absolute imports instead of relative;
2) Never import a class or a function from a module/submodule.