### PR TITLE
Update dependencies.rst

### DIFF
--- a/dependencies.rst
+++ b/dependencies.rst
@@ -65,6 +65,10 @@ Packages Not On PyPI
 
 Sometimes you'll want to use packages that are properly arranged with setuptools, but aren't published to PyPI. In those cases, you can specify a list of one or more ``dependency_links`` URLs where the package can be downloaded, along with some additional hints, and setuptools will find and install the package correctly.
 
+*Edit on 2017-03-23 : Dependency Links are now considered as depecrated in Python Wheels*
+
+*Reference: http://serverfault.com/questions/608192/pip-install-seems-to-be-ignoring-dependency-links *
+
 For example, if a library is published on GitHub, you can specify it like::
 
     setup(

--- a/dependencies.rst
+++ b/dependencies.rst
@@ -65,7 +65,7 @@ Packages Not On PyPI
 
 Sometimes you'll want to use packages that are properly arranged with setuptools, but aren't published to PyPI. In those cases, you can specify a list of one or more ``dependency_links`` URLs where the package can be downloaded, along with some additional hints, and setuptools will find and install the package correctly.
 
-*Edit on 2017-03-23 : Dependency Links are now considered as depecrated in Python Wheels*
+*Edit on 2017-03-23 : Dependency Links are now considered as deprecated in Python Wheels. `pip install` would not consider `dependency_links` in the installation.*
 
 *Reference: http://serverfault.com/questions/608192/pip-install-seems-to-be-ignoring-dependency-links *
 


### PR DESCRIPTION
Indicated that dependency_links are now considered as deprecated. 
Reference: http://serverfault.com/a/628714