### PR TITLE
added clarity for includes in MANIFEST files

### DIFF
--- a/non-code-files.rst
+++ b/non-code-files.rst
@@ -13,4 +13,4 @@ In order for these files to be copied at install time to the package's folder in
 
 .. note::
 
-    Files which are to be used by your installed library (e.g. data files to support a particular computation method) should usually be placed inside of the Python module directory itself. E.g. in our case, a data file might be at ``funniest/funniest/data.json``. That way, code which loads those files can easily specify a relative path from the consuming module's ``__file__`` variable.
+    Files which are to be used by your installed library (e.g. data files to support a particular computation method) should usually be placed inside of the Python module directory itself. E.g. in our case, a data file might be at ``funniest/funniest/data.json``. That way, code which loads those files can easily specify a relative path from the consuming module's ``__file__`` variable. Storing this file within the module directory would require updating the `include` in the above example to be `include funniest/funniest/data.json`, correspondingly.


### PR DESCRIPTION
I added 1 sentence to the "Note" on this page:

> Storing this file within the module directory would require updating the `include` in the above example to be `include funniest/funniest/data.json`, correspondingly.

I had been incorrectly using this feature and found the documentation unclear what degree of relative path to provide, so tried to remedy that.