### PR TITLE
Replace Youtube link with Wikipedia link

### DIFF
--- a/minimal.rst
+++ b/minimal.rst
@@ -1,7 +1,7 @@
 Minimal Structure
 =================
 
-We'll start with some Python code. Native German speakers, `please proceed with caution <http://www.youtube.com/watch?v=ienp4J3pW7U>`_::
+We'll start with some Python code. Native German speakers, `please proceed with caution <https://en.wikipedia.org/wiki/The_Funniest_Joke_in_the_World>`_::
 
     def joke():
         return (u'Wenn ist das Nunst\u00fcck git und Slotermeyer? Ja! ... '


### PR DESCRIPTION
The URL https://www.youtube.com/watch?v=ienp4J3pW7U now gives an error "Video unavailable. This video contains content from Believe Entertainment, who has blocked it on copyright grounds." You can find other instance of the sketch on Youtube (like https://www.youtube.com/watch?v=FBWr1KtnRcI) , but it probably is only a matter of time before those get blocked as well, so I have replaced the Youtube link with a link to Wikipedia.